### PR TITLE
プラグインの hooks を hooks.json に移行

### DIFF
--- a/plugins/github-project-manager/hooks/hooks.json
+++ b/plugins/github-project-manager/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/inject-project-state.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/inject-project-state.sh\"",
             "timeout": 15,
             "statusMessage": "プロジェクト状態を取得中..."
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/review-prompt.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/review-prompt.sh\"",
             "timeout": 10,
             "statusMessage": "ワークフロー確認中..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-issue-context.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-issue-context.sh\"",
             "timeout": 5
           }
         ]
@@ -40,32 +40,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-commit.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-commit.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-issue-create.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-issue-create.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-branch.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-branch.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-close.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-close.sh\"",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-pr-create.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-pr-create.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-project-create.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-project-create.sh\"",
             "timeout": 5
           }
         ]
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/auto-lint.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/auto-lint.sh\"",
             "timeout": 10
           }
         ]
@@ -87,22 +87,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/check-issue-type.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/check-issue-type.sh\"",
             "timeout": 5
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/auto-update-issue-status.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/auto-update-issue-status.sh\"",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/auto-done-status.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/auto-done-status.sh\"",
             "timeout": 15
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/auto-update-parent-checklist.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/auto-update-parent-checklist.sh\"",
             "timeout": 15
           }
         ]

--- a/plugins/sales-pipeline/hooks/hooks.json
+++ b/plugins/sales-pipeline/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/inject-sales-state.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/inject-sales-state.sh\"",
             "timeout": 15,
             "statusMessage": "営業パイプライン状態を取得中..."
           }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/scripts/auto-advance-stage.sh",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/auto-advance-stage.sh\"",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- hooks 定義を `settings.json` → `hooks/hooks.json` に移行（プラグインシステムの正しい構造）
- パスを `$CLAUDE_PROJECT_DIR` → `$CLAUDE_PLUGIN_ROOT` に変更
- 旧 `settings.json` を削除

## Test plan
- [ ] 他リポジトリで `/init-workflow` が認識されること
- [ ] SessionStart で hook が実行されること
- [ ] PreToolUse / PostToolUse の hook が動作すること

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)