### PR TITLE
Label / Type の切り分けルールを徹底（Type 語のラベル混入をブロック）

### DIFF
--- a/plugins/github-project-manager/README.md
+++ b/plugins/github-project-manager/README.md
@@ -133,8 +133,19 @@ github-project-manager/
 
 ## 設計方針
 
+### Label と Type の切り分け
+
+GitHub の 2 つの分類軸を明確に使い分ける:
+
+| 軸 | 意味 | 値 |
+|----|------|-----|
+| **Label（2 軸固定）** | いつ・どれくらい重要か | フェーズ（ヒアリング/見積もり/開発/テスト/納品）＋ 重要度（重要度:高/中/低） |
+| **Type（Issue Types）** | Issue の性質 | Task / Bug / Feature / Minutes / Acceptance |
+
+Type 語（bug/task/feature/minutes/acceptance/バグ/機能 等）を Label に混ぜると**「あれ、これ Type じゃないの？」となる**。`guard-issue-create.sh` が混入をブロックする。
+
 ### ハードゲート（bash で確定違反をブロック）
-Issue 番号なしコミット、未完了チェックリストでのクローズ、main ブランチでの直接編集など、
+Issue 番号なしコミット、未完了チェックリストでのクローズ、main ブランチでの直接編集、**Type 語の Label 混入**など、
 **ルールとして明確に違反とわかるもの**は hook で即ブロックし stderr で自己修正を促す。
 
 ### LLM 推論型監査（SessionStart で状態を注入）

--- a/plugins/github-project-manager/commands/new-acceptance.md
+++ b/plugins/github-project-manager/commands/new-acceptance.md
@@ -61,11 +61,12 @@ $ARGUMENTS
 必須設定:
 - `--title "検収: {対象}"`
 - `--body "..."`（上記テンプレ）
-- `--label "納品,重要度:<クライアント確認>"` もしくは `"検収,重要度:中"` — フェーズラベル体系に応じて
+- `--label "<フェーズ>,重要度:<クライアント確認>"` — **Label は フェーズ + 重要度の 2 軸のみ**。「検収」「acceptance」等の Type 語を Label に含めない
+  - フェーズは通常 `納品`。フェーズラベル体系に応じて
 - `--assignee {client-handle}` — **クライアントをアサイン**（開発者ではない）
 - `--project "<プロジェクト名>"`
 
-Type 設定（org リポジトリのみ）: `updateIssueIssueType` mutation で **`Acceptance`** に設定。
+**Type 設定**（org リポジトリのみ）: `updateIssueIssueType` mutation で **`Acceptance`** に設定。これが検収性質を表現する一次情報。
 
 ### 4. Relationships 設定
 

--- a/plugins/github-project-manager/commands/new-issue.md
+++ b/plugins/github-project-manager/commands/new-issue.md
@@ -25,9 +25,10 @@ $ARGUMENTS
 
 ### 必須設定
 1. `gh api user --jq '.login'` でアサイン
-2. フェーズラベル + 重要度ラベル（`--label "開発,重要度:中"` 等）
+2. **Label は フェーズ + 重要度の 2 軸のみ**（`--label "開発,重要度:中"` 等）
+   - Type 語（bug/task/feature/minutes/acceptance/バグ/機能/タスク/議事録/検収）を Label に含めない
 3. プロジェクト紐付け（`--project` で該当プロジェクトに追加）
-4. タイプ設定（`gh api graphql` で Issue Type 設定）
+4. **Type 設定**（`gh api graphql` の `updateIssueIssueType` で Task / Bug / Feature から選ぶ、org リポジトリのみ）
 
 ### 親子関係（該当する場合）
 - **GitHub Sub-issues API で親子関係を設定する**（`Parent: #N` テキストは使わない）

--- a/plugins/github-project-manager/commands/new-minutes.md
+++ b/plugins/github-project-manager/commands/new-minutes.md
@@ -96,11 +96,12 @@ md の内容を読み、以下に沿って Issue 本文を構成する:
 必須設定:
 - `--title "議事録: {会議タイトル} ({日付})"`
 - `--body "..."`（上記で組み立てた本文）
-- `--label "<フェーズ>,重要度:中"` — フェーズは議事の性質に応じて（ヒアリング/見積もり/開発/テスト/納品）。不明ならユーザーに確認
+- `--label "<フェーズ>,重要度:中"` — **Label は フェーズ + 重要度の 2 軸のみ**。「議事録」「minutes」等の Type 語を Label に含めない
+  - フェーズは議事の性質に応じて（ヒアリング/見積もり/開発/テスト/納品）。不明ならユーザーに確認
 - `--assignee tmyuu`（`gh api user --jq '.login'` で取得）
 - `--project "<プロジェクト名>"` — SessionStart の一覧から該当を選ぶ。複数プロジェクトに該当する場合はユーザー確認
 
-Type 設定（org リポジトリのみ）: `updateIssueIssueType` mutation で `Minutes` に設定。
+**Type 設定**（org リポジトリのみ）: `updateIssueIssueType` mutation で `Minutes` に設定。これが議事録性質を表現する一次情報。
 
 プロジェクトアイテムの Status を **Todo** に明示設定。
 

--- a/plugins/github-project-manager/commands/start.md
+++ b/plugins/github-project-manager/commands/start.md
@@ -24,7 +24,9 @@ $ARGUMENTS
 
 - Issue タイトルから短い slug を生成（英数字ハイフン、10-30 文字程度、全角は転記せず意訳してよい）
 - ブランチ名: `feature/#N-<slug>`（バグ修正の場合は `fix/#N-<slug>`）
-- ラベルに「bug」「バグ」が含まれていれば `fix/`、それ以外は `feature/`
+- **Issue Type が `Bug` なら `fix/`、それ以外は `feature/`**
+  - Type 取得: `gh api graphql -H "GraphQL-Features: issue_types" -f query='{ repository(owner:"OWNER", name:"REPO"){ issue(number:N){ issueType{ name } } } }'` 等
+  - 個人リポジトリなど Type が未設定の場合はタイトル・ラベルから推測せず `feature/` をデフォルトに
 - 既に同名ブランチがあれば `git checkout` で切替、無ければ `git checkout -b`
 - **current branch が main/master でない場合**、ユーザーに「作業中のブランチから切り替えていいか」を確認してから切る
 

--- a/plugins/github-project-manager/scripts/guard-issue-create.sh
+++ b/plugins/github-project-manager/scripts/guard-issue-create.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # PreToolUse: gh issue create に必須オプションが揃っていなければブロック
+# さらに --label に Type 語（bug/task/feature/minutes/acceptance/バグ/機能）が
+# 混入していたらブロックし、Issue Type での表現を誘導する。
 
 source "$(dirname "$0")/lib.sh"
 
@@ -12,8 +14,44 @@ is_first_line_cmd "$CMD" '^\s*gh\s+issue\s+create\b' || exit 0
 
 ERRORS=""
 
+# --- 必須オプション ---
 if ! echo "$CMD" | grep -qE '\-\-label'; then
   ERRORS="${ERRORS}--label が指定されていません。フェーズラベル + 重要度ラベルを付与してください。\n  例: --label \"開発,重要度:中\"\n  有効なフェーズ: ヒアリング / 見積もり / 開発 / テスト / 納品\n  有効な重要度: 重要度:高 / 重要度:中 / 重要度:低\n\n"
+else
+  # --label の値を抽出（quoted → unquoted の順で試行）
+  LABEL_VAL=$(echo "$CMD" | grep -oE '\-\-label[= ]"[^"]+"' | head -1 | sed -E 's/^--label[= ]"//; s/"$//')
+  if [ -z "$LABEL_VAL" ]; then
+    LABEL_VAL=$(echo "$CMD" | grep -oE "\-\-label[= ]'[^']+'" | head -1 | sed -E "s/^--label[= ]'//; s/'$//")
+  fi
+  if [ -z "$LABEL_VAL" ]; then
+    LABEL_VAL=$(echo "$CMD" | grep -oE '\-\-label[= ][^ ]+' | head -1 | sed -E 's/^--label[= ]//')
+  fi
+
+  # カンマ区切りで各ラベルを Type 語判定
+  TYPE_IN_LABEL=""
+  OLD_IFS=$IFS
+  IFS=','
+  for label in $LABEL_VAL; do
+    trimmed=$(echo "$label" | xargs)
+    lower=$(echo "$trimmed" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in
+      bug|task|feature|minutes|acceptance)
+        TYPE_IN_LABEL="$trimmed"
+        break
+        ;;
+    esac
+    case "$trimmed" in
+      バグ|機能|タスク|議事録|検収)
+        TYPE_IN_LABEL="$trimmed"
+        break
+        ;;
+    esac
+  done
+  IFS=$OLD_IFS
+
+  if [ -n "$TYPE_IN_LABEL" ]; then
+    ERRORS="${ERRORS}--label に Type 語「${TYPE_IN_LABEL}」が混入しています。\n  Type（Task / Bug / Feature / Minutes / Acceptance）は **GitHub Issue Type** で表現します。\n  Label は 2 軸のみ:\n    - フェーズ: ヒアリング / 見積もり / 開発 / テスト / 納品\n    - 重要度: 重要度:高 / 重要度:中 / 重要度:低\n  対応:\n    1. --label から Type 語を外す（例: --label \"開発,重要度:中\"）\n    2. Issue 作成後に updateIssueIssueType mutation で Type を設定（org リポジトリのみ）\n\n"
+  fi
 fi
 
 if ! echo "$CMD" | grep -qE '\-\-assignee'; then
@@ -26,7 +64,7 @@ fi
 
 if [ -n "$ERRORS" ]; then
   {
-    echo "gh issue create に必須オプションが不足しています:"
+    echo "gh issue create に問題があります:"
     echo ""
     echo -e "$ERRORS"
     echo "※ 作成前に SessionStart で注入された「オープン Issue」一覧を確認し、"

--- a/plugins/github-project-manager/skills/issue-lifecycle/SKILL.md
+++ b/plugins/github-project-manager/skills/issue-lifecycle/SKILL.md
@@ -22,9 +22,22 @@ user-invocable: false
 - タイトルは**クライアントが読むもの**として書く（技術用語を最小限に）
 - 内容は**後から見返して経緯がわかる**ように書く（背景・目的・完了条件）
 - アクションアイテムは**チェックリスト形式**で分解
-- ラベル（フェーズ + 重要度）・タイプ・アサイン・プロジェクト紐付けを**全て設定**
-- タイプは GraphQL API で設定（`gh issue create` では設定不可）
+- **Label と Type を混同しない**（詳細は下記「Label / Type の切り分け」）
+- アサイン・プロジェクト紐付けを**全て設定**
+- タイプは GraphQL API で設定（`gh issue create` では設定不可、org リポジトリのみ）
 - 親子関係は **GitHub Sub-issues（relationships）** で設定する（`Parent: #N` テキストは使わない）
+
+### Label / Type の切り分け
+
+| 軸 | 意味 | 値 |
+|----|------|-----|
+| **Label（2 軸固定）** | いつ・どれくらい重要か | フェーズ（ヒアリング/見積もり/開発/テスト/納品）＋ 重要度（重要度:高/中/低） |
+| **Type（GitHub Issue Types）** | Issue の性質 | Task / Bug / Feature / Minutes / Acceptance |
+
+- **Type 語（bug/task/feature/minutes/acceptance、日本語の バグ/機能/タスク/議事録/検収）を Label として使わない**
+  - 例: ❌ `--label "bug,開発,重要度:中"`
+  - 例: ✓ `--label "開発,重要度:中"` + Issue 作成後に updateIssueIssueType で Type=Bug 設定
+- `guard-issue-create.sh` が Type 語の Label 混入をブロックする
 
 ## Issue 更新
 
@@ -112,6 +125,7 @@ user-invocable: false
 
 - Issue 番号なしのコミット
 - 未完了チェックリストを残したまま Issue / PR をクローズ（全経路でブロックされる）
+- **Type 語を Label として使う**（bug/task/feature/minutes/acceptance/バグ/機能 等。Type は Issue Types で表現する。guard-issue-create がブロック）
 - ラベルやタイプの後からの変更（原則。typo 修正は可）
 - ユーザーに確認せずに Issue をクローズ
 - `git push --force` を main ブランチに実行


### PR DESCRIPTION
## Summary

- `guard-issue-create.sh` を拡張: `--label` に Type 語（bug/task/feature/minutes/acceptance・バグ/機能/タスク/議事録/検収）が含まれていたら exit 2 でブロック
- `commands/start.md` の判定を「Type が Bug なら `fix/`」に修正（誤った「ラベルに bug があれば fix/」を廃止）
- ドキュメント全般に Label/Type 切り分けルールを明記

## Label と Type の切り分け

| 軸 | 意味 | 値 |
|----|------|-----|
| **Label（2 軸固定）** | いつ・どれくらい重要か | フェーズ（ヒアリング/見積もり/開発/テスト/納品）＋ 重要度（重要度:高/中/低） |
| **Type（Issue Types）** | Issue の性質 | Task / Bug / Feature / Minutes / Acceptance |

## Test plan

- [x] `--label "bug,開発,重要度:中"` → exit 2（bug 検知）
- [x] `--label "開発,バグ,重要度:中"` → exit 2（バグ検知）
- [x] `--label "Feature,開発,重要度:中"` → exit 2（大文字 Feature 検知）
- [x] `--label "開発,重要度:中"` → exit 0（正常）
- [x] `--label "納品,重要度:高"` → exit 0（`重要度:中` の中にある 'a' 等に誤反応しない）

Closes #81