### PR TITLE
/new-project コマンド追加（空リポからの Project ブートストラップ）

### DIFF
--- a/plugins/github-project-manager/.claude-plugin/plugin.json
+++ b/plugins/github-project-manager/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github-project-manager",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "GitHub を「型に沿って使いこなす PM」として振る舞う。4 軸（型通り/親子/ステータス/完了条件）で Issue/PR を制御。taxonomy.json で分類基準を一元管理。",
   "author": {
     "name": "tmyuu"

--- a/plugins/github-project-manager/README.md
+++ b/plugins/github-project-manager/README.md
@@ -50,6 +50,10 @@ CLAUDE.md 追記に加え、**taxonomy.json に沿って GitHub Label を同期*
 ## ワークフロー
 
 ```
+  [初期セットアップ]
+   /new-project   → Project 作成 + リポジトリリンク（空リポからのブートストラップ）
+   /init-workflow → CLAUDE.md 整備 + Label 同期
+
   [起点コマンド]                                [作業開始]
    ┌─ /new-issue       (Task/Bug/Feature) ─┐
    ├─ /new-minutes     (議事録)            │
@@ -95,6 +99,7 @@ CLAUDE.md 追記に加え、**taxonomy.json に沿って GitHub Label を同期*
 
 | コマンド | 説明 |
 |---------|------|
+| `/new-project` | GitHub Project (v2) を作成 + リポジトリにリンク（空リポからのブートストラップ） |
 | `/init-workflow` | CLAUDE.md を生成/更新。taxonomy に沿って GitHub Label を同期 |
 | `/new-issue` | Task/Bug/Feature 向け汎用 Issue 作成 |
 | `/new-minutes` | 議事録 md → Minutes Issue（md 未作成なら `docs/meetings/` にテンプレ生成） |
@@ -113,7 +118,7 @@ CLAUDE.md 追記に加え、**taxonomy.json に沿って GitHub Label を同期*
 | guard-branch.sh | PreToolUse(Bash) | 1 | ブランチ名の #N + Issue 実在・状態(open)検証 |
 | guard-issue-create.sh | PreToolUse(Bash) | 1 | **taxonomy 駆動**で Label/Type 検証、Type 語混入ブロック |
 | guard-pr-create.sh | PreToolUse(Bash) | 1 | 必須オプション + Closes #N + **taxonomy 駆動 Label 検証** |
-| guard-project-create.sh | PreToolUse(Bash) | 3 | プロジェクト新規作成をブロック |
+| guard-project-create.sh | PreToolUse(Bash) | 3 | プロジェクト新規作成をブロック（`/new-project` の `CLAUDE_NEW_PROJECT_ALLOW=1` で例外通過） |
 | guard-close.sh | PreToolUse(Bash) | 4 | **全経路で未完了チェックリストのクローズをブロック** |
 | review-issue-type.sh | PostToolUse(Bash) | 1 | org リポジトリでの Issue Type 設定リマインド |
 | auto-status-transition.sh | PostToolUse(Bash) | 3 | commit → In Progress、close/merge → Done |
@@ -143,6 +148,7 @@ github-project-manager/
 ├── agents/
 │   └── issue-manager.md
 ├── commands/
+│   ├── new-project.md                 # Project 作成 + リポリンク
 │   ├── init-workflow.md               # CLAUDE.md + Label 同期
 │   ├── new-issue.md
 │   ├── new-minutes.md

--- a/plugins/github-project-manager/commands/new-project.md
+++ b/plugins/github-project-manager/commands/new-project.md
@@ -1,0 +1,97 @@
+---
+description: "GitHub Project (v2) を新規作成し、現在のリポジトリにリンクする。空リポからのブートストラップ用。"
+---
+
+新しい GitHub Project (v2) を作成し、現在のリポジトリにリンクしてください。
+
+## 引数
+
+$ARGUMENTS
+
+引数の解釈:
+- 文字列が渡されたら **タイトル** として扱う（例: `/new-project 案件A 開発`）
+- `--link <N>` のみが渡された場合は **既存 Project N をリンクするだけ**（作成しない）
+- 引数なしならユーザーに「タイトルは？」と確認（デフォルト提案: リポジトリ名）
+
+## 前提と注意
+
+- このコマンドは `guard-project-create.sh` のブロックを **`CLAUDE_NEW_PROJECT_ALLOW=1` 環境変数プレフィックス** で明示的にバイパスする。バイパスは `gh project create` の 1 行限定で使うこと。
+- 既に同じ Owner に Project が存在する場合は **そちらに紐付ける選択肢をユーザーに提示**してから新規作成へ進むこと。
+- 個人リポジトリ・組織リポジトリどちらでも動作する（`gh repo view --json owner -q .owner.login` で実所有者を取得）。
+
+## 手順
+
+### 1. リポジトリ情報取得
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib.sh"
+get_repo_info  # REPO / OWNER / REPO_NAME がエクスポートされる
+```
+
+`gh repo view --json owner --jq '.owner.login'` で **実 owner**（個人 or org）を確認。Project は repo owner と同じスコープに作成するのが原則。
+
+### 2. 既存 Project の確認
+
+SessionStart で注入済みの「プロジェクト」一覧を確認。リポジトリにリンク済み Project (`リポリンク:✓`) があればユーザーに確認:
+
+> 「既に `<title>` (#<N>) がリンクされています。新規作成しますか？それともこの Project に紐付けて続行しますか？」
+
+リンク先候補（リポリンク:✗ の Project）があれば「これらにリンクする選択肢もあります」と案内。
+
+`--link <N>` モードの場合は Step 3 をスキップして Step 4 へ。
+
+### 3. Project 作成
+
+タイトルが未確定ならユーザー確認。デフォルト提案は `<REPO_NAME>`。
+
+```bash
+CLAUDE_NEW_PROJECT_ALLOW=1 gh project create \
+  --owner "$OWNER" \
+  --title "<TITLE>" \
+  --format json
+```
+
+返却 JSON から `number` と `url` を取得。
+
+### 4. リポジトリリンク
+
+```bash
+gh project link <NUMBER> --owner "$OWNER" --repo "$REPO"
+```
+
+`gh project link` は `guard-project-create.sh` の対象外なので env prefix は不要。
+
+### 5. Status フィールドの確認
+
+GitHub Projects v2 の **デフォルト Status フィールド** は `Todo / In Progress / Done` で `config/taxonomy.json` の `status.flow` と一致するため、追加の初期化は不要。
+
+念のため確認したい場合:
+
+```bash
+gh project field-list <NUMBER> --owner "$OWNER" --format json | jq '.fields[] | select(.name=="Status") | .options[].name'
+```
+
+`Todo` / `In Progress` / `Done` が揃っていない場合のみユーザーに知らせる（自動修正はしない、手動 UI 推奨）。
+
+### 6. 完了報告と次アクション案内
+
+以下を端的に報告:
+
+- 作成 / 利用した Project: `<title>` (#<N>) — `<url>`
+- リポリンク完了
+- 次に推奨するアクション:
+  1. `/init-workflow` — `.claude/CLAUDE.md` の整備と Label 同期
+  2. `/new-issue` — 最初の Issue を作成（`--project` に今作った Project 番号を指定）
+
+## 禁止事項
+
+- `CLAUDE_NEW_PROJECT_ALLOW=1` を `gh project create` 以外のコマンドに付けない
+- 同名 Project が既にリンクされている場合、ユーザーに確認せず新規作成しない
+- リポリンクなしで放置しない（リンク失敗時はエラー報告して中断、Project は残す）
+- README / CLAUDE.md の編集は行わない（責務は `/init-workflow` に委譲）
+
+## エラーハンドリング
+
+- `gh auth status` 失敗 → 認証を促して中断
+- `gh project create` 失敗（権限不足等）→ stderr をそのまま提示し中断
+- `gh project link` 失敗 → 作成済み Project の情報は残し、ユーザーに手動リンクの方法を案内（`gh project link <N> --owner <owner> --repo <owner/repo>`）

--- a/plugins/github-project-manager/scripts/guard-project-create.sh
+++ b/plugins/github-project-manager/scripts/guard-project-create.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # PreToolUse: プロジェクト新規作成をブロック（既存プロジェクトへの紐付けが原則）
+# 例外: /new-project コマンドは CLAUDE_NEW_PROJECT_ALLOW=1 を頭に付けて実行することで通過する
 
 source "$(dirname "$0")/lib.sh"
 
@@ -8,6 +9,11 @@ has_jq || exit 0
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | read_command)
 
+# /new-project からの明示的バイパス（コマンド先頭の env prefix を検出）
+if echo "$CMD" | head -1 | grep -qE '^\s*CLAUDE_NEW_PROJECT_ALLOW=1\s'; then
+  exit 0
+fi
+
 if is_first_line_cmd "$CMD" '^\s*gh\s+project\s+create\b'; then
   cat >&2 <<'FEEDBACK'
 プロジェクトの新規作成はブロックされました。
@@ -15,11 +21,11 @@ if is_first_line_cmd "$CMD" '^\s*gh\s+project\s+create\b'; then
 原則:
 - プロジェクトは既存のものに紐付けてください
 - SessionStart で注入された「プロジェクト」一覧を確認してください
-- 新規プロジェクトが本当に必要な場合は、Issue を作成してユーザーに提案してください
 
-既存プロジェクトに該当がない場合の手順:
-1. /new-issue で「新規プロジェクト作成の提案」Issue を作成
-2. ユーザーの承認を得てから作成
+新規 Project が本当に必要な場合:
+- /new-project コマンドを使用してください（作成 + リポリンクを一括で実行）
+  例: /new-project 案件A 開発
+- /new-project は内部で CLAUDE_NEW_PROJECT_ALLOW=1 を付けてこのガードをバイパスします
 FEEDBACK
   exit 2
 fi
@@ -30,7 +36,7 @@ GraphQL によるプロジェクト新規作成はブロックされました。
 
 原則:
 - プロジェクトは既存のものに紐付けてください
-- 新規プロジェクトが必要な場合は Issue でユーザーに提案してください
+- 新規 Project が必要なら /new-project コマンドを使用してください
 FEEDBACK
   exit 2
 fi

--- a/plugins/github-project-manager/scripts/inject-project-state.sh
+++ b/plugins/github-project-manager/scripts/inject-project-state.sh
@@ -81,6 +81,8 @@ if [ -n "$PROJECTS_JSON" ] && [ "$PROJECTS_JSON" != "null" ] && [ "$PROJECTS_JSO
   ' 2>/dev/null
 else
   echo "（プロジェクトなし）"
+  echo ""
+  echo "ヒント: 紐付け先 Project が必要なら \`/new-project\` で作成 + リポリンクできます。"
 fi
 echo ""
 

--- a/plugins/github-project-manager/scripts/review-prompt.sh
+++ b/plugins/github-project-manager/scripts/review-prompt.sh
@@ -14,6 +14,21 @@ BRANCH_ISSUE=$(echo "$BRANCH" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1
 OPEN_ISSUES=$(gh issue list --limit 15 --state open --json number,title --jq '.[] | "#\(.number) \(.title)"' 2>/dev/null)
 
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  # 紐付け先 Project が 1 つも無いリポジトリでは Issue を作っても --project が指定できない。
+  # 先に /new-project でブートストラップする必要があるかをチェックする。
+  PROJECT_BOOTSTRAP_HINT=""
+  if get_repo_info 2>/dev/null; then
+    LINKED_COUNT=$(gh api graphql -f query="
+      {
+        repository(owner: \"$OWNER\", name: \"$REPO_NAME\") {
+          projectsV2(first: 5) { totalCount }
+        }
+      }" --jq '.data.repository.projectsV2.totalCount // 0' 2>/dev/null)
+    if [ -z "$LINKED_COUNT" ] || [ "$LINKED_COUNT" = "0" ]; then
+      PROJECT_BOOTSTRAP_HINT=$'\n**注意: このリポジトリにリンク済みの Project がありません。** Issue 作成前に `/new-project` で Project をブートストラップしてください。'
+    fi
+  fi
+
   cat <<GUIDANCE
 ## ワークフローリマインド
 
@@ -25,7 +40,7 @@ if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
 
 ### オープン Issue
 ${OPEN_ISSUES:-（なし）}
-
+${PROJECT_BOOTSTRAP_HINT}
 **重要: main ブランチ上でのソースコード編集はブロックされます。必ず Issue を確定し、feature ブランチを作成してから着手してください。**
 GUIDANCE
 elif [ -n "$BRANCH_ISSUE" ]; then

--- a/plugins/github-project-manager/skills/issue-lifecycle/SKILL.md
+++ b/plugins/github-project-manager/skills/issue-lifecycle/SKILL.md
@@ -83,8 +83,9 @@ user-invocable: false
 - **GitHub Projects v2** のみ対応。プロジェクトに紐付いていない Issue は遷移しない
 
 ### プロジェクト管理
-- プロジェクトは**既存のものに紐付ける**（新規作成は `guard-project-create.sh` でブロック）
-- プロジェクト作成後は**必ずリポジトリにリンク**する（`linkProjectV2ToRepository`）
+- プロジェクトは**既存のものに紐付ける**のが原則（直接の `gh project create` は `guard-project-create.sh` でブロック）
+- 新規 Project が必要な場合は **`/new-project` を使う**（作成 + リポジトリリンクを一括、`CLAUDE_NEW_PROJECT_ALLOW=1` で例外通過）
+- リポリンクなしの Project を放置しない（SessionStart で `リポリンク:✗` として検出される）
 - Issue は `--project` で紐付け
 
 ### 検収（Acceptance）のステータス運用


### PR DESCRIPTION
## Summary

- 空リポジトリで Project が存在せず Issue 作成 (`--project` 必須) と Project 作成 (`guard-project-create` でブロック) が両方詰むデッドロックを解消
- `/new-project` コマンドで `gh project create` + `gh project link` を一発実行
- `guard-project-create.sh` は `CLAUDE_NEW_PROJECT_ALLOW=1` の env prefix を頭に付けた場合のみバイパス（明示的・限定的）
- main ブランチでの UserPromptSubmit / SessionStart に Project 不在時の `/new-project` 案内を追加

## 変更ファイル

| 種別 | ファイル |
|---|---|
| 新規 | `commands/new-project.md` |
| 修正 | `scripts/guard-project-create.sh` (env prefix バイパス) |
| 修正 | `scripts/review-prompt.sh` (main で Project 不在検出時の案内) |
| 修正 | `scripts/inject-project-state.sh` (`（プロジェクトなし）` のヒント) |
| 修正 | `README.md` (Workflow / Commands / Hooks / 構成図) |
| 修正 | `skills/issue-lifecycle/SKILL.md` (軸 3 のプロジェクト管理) |
| 修正 | `.claude-plugin/plugin.json` 3.0.0 → 3.1.0 |

## 設計判断

- **field 初期化は no-op**: GitHub Projects v2 のデフォルト Status (`Todo / In Progress / Done`) が `taxonomy.json` の `status.flow` と一致するため、追加初期化は不要と判明
- **責務分離**: `/new-project` は Project 作成 + リポリンクまで。CLAUDE.md / Label 同期は既存の `/init-workflow` に委譲
- **既存 Project がある場合**: SessionStart で注入済みの一覧を踏まえてユーザーに確認 + `--link <N>` モードでリンクのみも可能

## Test plan

- [x] `bash -n` で 3 スクリプト構文チェック通過
- [x] `guard-project-create.sh` バイパスのスモークテスト 5 ケース通過（バイパス OK / 通常ブロック / 無関係スルー / link スルー / 既存パターン維持）
- [ ] 別の空リポジトリで `/new-project` を実機実行（PR レビュー時 or マージ後に動作確認）

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)